### PR TITLE
[PROPOSAL] Raise the SCSS selector depth limit to 3

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,2 +1,5 @@
 ruby:
   config_file: .rubocop.yml
+
+scss:
+  config_file: .scss-lint.yml

--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -1,0 +1,8 @@
+scss_files: 'app/assets/**/*.scss'
+
+exclude: 'vendor/**'
+
+linters:
+  SelectorDepth:
+    enabled: true
+    max_depth: 3


### PR DESCRIPTION
I think we should raise the SCSS selector depth from 2 to 3 (the scss-lint default; hound is enforcing 2..)


We're dealing both with a lot of legacy CSS, and a pretty complex CSS inheritance across multiple projects. Add to that how many HTML templates are outside our immediate control, and it seems like we get into trouble fast.

From the scss-lint docs:

```
Bad: selectors with depths of 4

.one .two .three > .four {
  ...
}

.one .two {
  .three > .four {
    ...
  }
}

Good

.one .two .three {
  ...
}

.one .two {
  .three {
    ...
  }
}
```

