### PR TITLE
Override bootstrap navbar colors to use our beige palette

### DIFF
--- a/app/assets/stylesheets/variables.scss
+++ b/app/assets/stylesheets/variables.scss
@@ -24,6 +24,10 @@ $navbar-inverse-link-color: lighten($gray-base, 86%);
 $sul-masthead-bg-color: $color-beige-10;
 $sul-footer-bg-color: $color-beige-10;
 
+$navbar-default-bg: $color-beige-05;
+$navbar-default-link-hover-bg: $color-beige-20;
+$navbar-default-link-active-bg: $color-beige-10;
+
 $font-family-sans-serif: "Source Sans Pro", "Arial Unicode MS", Helvetica, sans-serif;
 $headings-font-family: "Source Sans Pro", "Arial Unicode MS", Helvetica, sans-serif;
 $sul-link-color-border: $color-pantone-401;


### PR DESCRIPTION
After:

<img width="427" alt="screen shot 2015-12-02 at 4 40 55 pm" src="https://cloud.githubusercontent.com/assets/111218/11548648/87e1d19a-9913-11e5-9206-7dfc09b78360.png">
